### PR TITLE
Cloudflare Pagesデプロイ設定を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,47 @@ A web application that allows children to create their own original lineage tree
         -   Implement functionality to save the tree as an image and to save the application state.
     6.  **Improve Design:** (Ongoing)
         -   Replace the basic circles and lines with illustration-based designs.
+
+## 4. Deployment to Cloudflare Pages
+
+This project can be deployed as a static site to Cloudflare Pages.
+
+### Prerequisites
+
+-   [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/) (or [Yarn](https://yarnpkg.com/)) installed.
+-   A [Cloudflare account](https://dash.cloudflare.com/sign-up).
+-   [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/) installed and configured. You can install it globally or use `npx`.
+
+### Deployment Steps
+
+1.  **Install dependencies:**
+    If you haven't already, install the `wrangler` CLI. If you are using the `package.json` provided, you can install it as a dev dependency:
+    ```bash
+    npm install
+    # or
+    yarn install
+    ```
+
+2.  **Login to Cloudflare (if using Wrangler CLI directly for the first time):**
+    ```bash
+    npx wrangler login
+    ```
+
+3.  **Deploy the application:**
+    You can deploy the application using the npm script defined in `package.json`:
+    ```bash
+    npm run deploy
+    # or
+    yarn deploy
+    ```
+    This command utilizes `wrangler pages deploy .` to deploy the contents of the current directory.
+
+    Alternatively, you can run the Wrangler command directly:
+    ```bash
+    npx wrangler pages deploy .
+    ```
+
+### Configuration
+
+-   **`wrangler.toml`**: This file contains the configuration for Wrangler, including the project name and compatibility date. The `pages_build_output_dir` is set to `"."` because all static assets (`index.html`, `style.css`, `app.js`) are in the root directory.
+-   **`package.json`**: Includes a `deploy` script that simplifies the deployment process.

--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ This project can be deployed as a static site to Cloudflare Pages.
     # or
     yarn deploy
     ```
-    This command executes `npx wrangler pages deploy .`, deploying the contents of the current directory to Cloudflare Pages.
+    This command executes `wrangler pages deploy .` (utilizing the locally installed Wrangler from `devDependencies`), deploying the contents of the current directory to Cloudflare Pages.
 
     Alternatively, if you have `wrangler` installed globally or prefer to run it directly:
     ```bash
-    npx wrangler pages deploy .
+    npx wrangler pages deploy . # or simply `wrangler pages deploy .` if wrangler is in your PATH
     ```
 
 ### Configuration
@@ -99,4 +99,4 @@ This project can be deployed as a static site to Cloudflare Pages.
     -   `pages_build_output_dir = "."`: Tells Wrangler that the static assets to be deployed are in the root directory of the project. This is the standard way to specify the assets directory for Cloudflare Pages in recent Wrangler versions.
 -   **`package.json`**:
     -   Includes `wrangler` (version `^4.0.0`) as a dev dependency.
-    -   Defines a `deploy` script (`npx wrangler pages deploy .`) for easy deployment.
+    -   Defines a `deploy` script (`wrangler pages deploy .`) for easy deployment. This leverages the `wrangler` binary installed as part of the project's dependencies.

--- a/README.md
+++ b/README.md
@@ -55,19 +55,24 @@ This project can be deployed as a static site to Cloudflare Pages.
 
 -   [Node.js](https://nodejs.org/) and [npm](https://www.npmjs.com/) (or [Yarn](https://yarnpkg.com/)) installed.
 -   A [Cloudflare account](https://dash.cloudflare.com/sign-up).
--   [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/) installed and configured. You can install it globally or use `npx`.
+-   [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/get-started/) (version 4 or later recommended) installed and configured.
 
 ### Deployment Steps
 
-1.  **Install dependencies:**
-    If you haven't already, install the `wrangler` CLI. If you are using the `package.json` provided, you can install it as a dev dependency:
+1.  **Install dependencies (including Wrangler v4):**
+    This project uses `wrangler` for deployment. It's listed as a dev dependency in `package.json`.
+    To install `wrangler` (version `^4.0.0` or later) and other potential dependencies, run:
     ```bash
     npm install
     # or
     yarn install
     ```
+    If you want to install `wrangler` globally or update an existing global installation, you can run:
+    ```bash
+    npm install --global wrangler@4
+    ```
 
-2.  **Login to Cloudflare (if using Wrangler CLI directly for the first time):**
+2.  **Login to Cloudflare (if using Wrangler CLI directly for the first time or session expired):**
     ```bash
     npx wrangler login
     ```
@@ -79,14 +84,19 @@ This project can be deployed as a static site to Cloudflare Pages.
     # or
     yarn deploy
     ```
-    This command utilizes `wrangler pages deploy .` to deploy the contents of the current directory.
+    This command executes `npx wrangler pages deploy .`, deploying the contents of the current directory to Cloudflare Pages.
 
-    Alternatively, you can run the Wrangler command directly:
+    Alternatively, if you have `wrangler` installed globally or prefer to run it directly:
     ```bash
     npx wrangler pages deploy .
     ```
 
 ### Configuration
 
--   **`wrangler.toml`**: This file contains the configuration for Wrangler, including the project name and compatibility date. The `pages_build_output_dir` is set to `"."` because all static assets (`index.html`, `style.css`, `app.js`) are in the root directory.
--   **`package.json`**: Includes a `deploy` script that simplifies the deployment process.
+-   **`wrangler.toml`**: This file contains the configuration for Wrangler.
+    -   `name`: Specifies the project name on Cloudflare.
+    -   `compatibility_date`: Ensures consistent behavior across Wrangler versions.
+    -   `pages_build_output_dir = "."`: Tells Wrangler that the static assets to be deployed are in the root directory of the project. This is the standard way to specify the assets directory for Cloudflare Pages in recent Wrangler versions.
+-   **`package.json`**:
+    -   Includes `wrangler` (version `^4.0.0`) as a dev dependency.
+    -   Defines a `deploy` script (`npx wrangler pages deploy .`) for easy deployment.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "my-own-organism-lineage-maker",
+  "version": "1.0.0",
+  "description": "A web application that allows children to create their own original lineage trees of organisms.",
+  "scripts": {
+    "deploy": "npx wrangler pages deploy ."
+  },
+  "devDependencies": {
+    "wrangler": "^3.0.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "A web application that allows children to create their own original lineage trees of organisms.",
   "scripts": {
-    "deploy": "npx wrangler pages deploy ."
+    "deploy": "wrangler pages deploy ."
   },
   "devDependencies": {
     "wrangler": "^4.0.0"

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
     "deploy": "npx wrangler pages deploy ."
   },
   "devDependencies": {
-    "wrangler": "^3.0.0"
+    "wrangler": "^4.0.0"
   }
 }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,7 @@
+name = "my-own-organism-lineage-maker"
+compatibility_date = "2024-03-18"
+
+[pages]
+# 静的アセットが格納されているディレクトリ
+# このプロジェクトではルートディレクトリにHTML、CSS、JSファイルがあるので "." を指定
+build_output_dir = "."

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,7 +1,3 @@
 name = "my-own-organism-lineage-maker"
 compatibility_date = "2024-03-18"
-
-[pages]
-# 静的アセットが格納されているディレクトリ
-# このプロジェクトではルートディレクトリにHTML、CSS、JSファイルがあるので "." を指定
-build_output_dir = "."
+pages_build_output_dir = "."


### PR DESCRIPTION
プロジェクトをCloudflare Pagesにデプロイするための設定ファイル (`wrangler.toml`, `package.json`) を追加し、READMEにデプロイ手順を記載しました。

- `wrangler.toml`: プロジェクト名、互換日、ビルド出力ディレクトリを設定。
- `package.json`: `wrangler` を開発依存関係として追加し、`deploy` スクリプトを定義。
- `README.md`: Cloudflare Pagesへのデプロイ手順を追記。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added detailed instructions for deploying the project to Cloudflare Pages in the README.  
* **Chores**
  * Introduced new configuration and metadata files to support deployment settings.
  * Added a deployment script and development dependency for streamlined deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->